### PR TITLE
mention nsx edge support in os types

### DIFF
--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -210,6 +210,9 @@
   * [Edgeos](/lib/oxidized/model/edgeos.rb)
   * [EdgeSwitch](/lib/oxidized/model/edgeswitch.rb)
   * [AirFiber](/lib/oxidized/model/airfiber.rb)
+* VMWare
+  * [NSX Edge (configuration)](/lib/oxidized/model/nsxconfig.rb)
+  * [NSX Edge (firewall rules)](/lib/oxidized/model/nsxfirewall.rb)
 * Watchguard
   * [Fireware OS](/lib/oxidized/model/firewareos.rb)
 * Westell


### PR DESCRIPTION
Adds the newly added `NSX Edge` model to `Supported-OS-Types.md` so that users can discover this model.